### PR TITLE
Add 'i' to additional_attrs

### DIFF
--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -29,13 +29,13 @@
 #   ***each attribute receives only one value***
 #
 define tac_plus::group (
-  $group           = $name,
-  $default_service = '',
-  $member          = '',
-  $service         = {},
-  $protocol        = {},
-  $cmd             = {},
-  $addtional_attrs = {},
+  $group            = $name,
+  $default_service  = '',
+  $member           = '',
+  $service          = {},
+  $protocol         = {},
+  $cmd              = {},
+  $additional_attrs = {},
 ) {
 
   concat::fragment {"group-${group}":


### PR DESCRIPTION
This matches the spelling in the template/ and documentation